### PR TITLE
update tcp_server to allow for usb CMakeLists.txt

### DIFF
--- a/pico_w/wifi/tcp_server/CMakeLists.txt
+++ b/pico_w/wifi/tcp_server/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(picow_tcpip_server_background
         pico_cyw43_arch_lwip_threadsafe_background
         pico_stdlib
         )
-
+pico_enable_stdio_usb(picow_tcpip_server_background 1)
 pico_add_extra_outputs(picow_tcpip_server_background)
 
 add_executable(picow_tcpip_server_poll
@@ -31,4 +31,5 @@ target_link_libraries(picow_tcpip_server_poll
         pico_cyw43_arch_lwip_poll
         pico_stdlib
         )
+pico_enable_stdio_usb(picow_tcpip_server_poll 1)
 pico_add_extra_outputs(picow_tcpip_server_poll)


### PR DESCRIPTION
without picow_tcpip_server_poll the printf's do not show anywhere.  Burned hours wondering if the code was running.  

Should we think about making all of the examples turn on usb stdio by default?    Since you have to used the USB to install the app it sure would make it easy to see debug every example was set to show stdio to the usb serial.